### PR TITLE
Un-ignore app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,6 @@ basic/frontend/.cache/
 basic/frontend/.spago/
 basic/out/
 basic/.idea/
-basic/app/
 basic/frontend/node_modules/
 basic/haskell-purescript-hello-world.cabal
 basic/haskell-purescript-hello-world.iml

--- a/basic/app/Main.hs
+++ b/basic/app/Main.hs
@@ -1,0 +1,7 @@
+module Main where
+
+import Protolude
+import Scaffolding.Init (runApp)
+
+main :: IO ()
+main = runApp


### PR DESCRIPTION
Fixes the following error:
```
Preprocessing executable 'haskell-purescript-hello-world-server' for haskell-purescript-hello-world-0.1.0.0..
Cabal-simple_mPHDZzAJ_2.2.0.1_ghc-8.4.4: can't find source for Main in app
```